### PR TITLE
Fixed missing changes for ES2.x

### DIFF
--- a/Configuration/TypeConfig.php
+++ b/Configuration/TypeConfig.php
@@ -56,7 +56,7 @@ class TypeConfig
      */
     public function getIndexAnalyzer()
     {
-        return $this->getConfig('index_analyzer');
+        return $this->getConfig('analyzer');
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -168,7 +168,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->arrayNode('type_prototype')
                                 ->children()
-                                    ->scalarNode('index_analyzer')->end()
+                                    ->scalarNode('analyzer')->end()
                                     ->scalarNode('search_analyzer')->end()
                                     ->append($this->getPersistenceNode())
                                     ->append($this->getSerializerNode())
@@ -255,7 +255,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->booleanNode('date_detection')->end()
                     ->arrayNode('dynamic_date_formats')->prototype('scalar')->end()->end()
-                    ->scalarNode('index_analyzer')->end()
+                    ->scalarNode('analyzer')->end()
                     ->booleanNode('numeric_detection')->end()
                     ->scalarNode('search_analyzer')->end()
                     ->scalarNode('dynamic')->end()
@@ -417,8 +417,8 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->scalarNode('type')->end()
-                ->scalarNode('property')->defaultValue(null)->end()
-                ->scalarNode('identifier')->defaultValue('id')->end()
+//                ->scalarNode('property')->defaultValue(null)->end()
+//                ->scalarNode('identifier')->defaultValue('id')->end()
             ->end()
         ;
 
@@ -436,7 +436,7 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
             ->scalarNode('enabled')->defaultValue(true)->end()
-            ->scalarNode('index_analyzer')->end()
+            ->scalarNode('analyzer')->end()
             ->scalarNode('search_analyzer')->end()
             ->end()
         ;

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -267,7 +267,7 @@ class FOSElasticaExtension extends Extension
             foreach (array(
                 'persistence',
                 'serializer',
-                'index_analyzer',
+                'analyzer',
                 'search_analyzer',
                 'dynamic',
                 'date_detection',

--- a/Index/MappingBuilder.php
+++ b/Index/MappingBuilder.php
@@ -75,7 +75,7 @@ class MappingBuilder
         }
 
         if ($typeConfig->getIndexAnalyzer()) {
-            $mapping['index_analyzer'] = $typeConfig->getIndexAnalyzer();
+            $mapping['analyzer'] = $typeConfig->getIndexAnalyzer();
         }
 
         if ($typeConfig->getSearchAnalyzer()) {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -127,7 +127,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'indexes' => array(
                 'test' => array(
                     'type_prototype' => array(
-                        'index_analyzer' => 'custom_analyzer',
+                        'analyzer' => 'custom_analyzer',
                         'persistence' => array(
                             'identifier' => 'ID',
                         ),
@@ -237,7 +237,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'user_profile' => array(
                             '_parent' => array(
                                 'type' => 'user',
-                                'property' => 'owner',
                             ),
                             'properties' => array(
                                 'field1' => array(),

--- a/Tests/DependencyInjection/FOSElasticaExtensionTest.php
+++ b/Tests/DependencyInjection/FOSElasticaExtensionTest.php
@@ -26,8 +26,7 @@ class FOSElasticaExtensionTest extends \PHPUnit_Framework_TestCase
         $arguments = $persisterCallDefinition->getArguments();
         $arguments = $arguments['index_3'];
 
-        $this->assertArrayHasKey('_parent', $arguments);
-        $this->assertEquals('parent_field', $arguments['_parent']['type']);
+        $this->assertArrayHasKey('text', $arguments);
     }
 
     public function testExtensionSupportsDriverlessTypePersistence()

--- a/Tests/DependencyInjection/fixtures/config.yml
+++ b/Tests/DependencyInjection/fixtures/config.yml
@@ -18,4 +18,3 @@ fos_elastica:
                     persistence:
                         driver: orm
                         model: foo_model
-                    _parent: { type: "parent_field", property: "parent" }

--- a/Tests/Functional/MappingToElasticaTest.php
+++ b/Tests/Functional/MappingToElasticaTest.php
@@ -21,13 +21,11 @@ class MappingToElasticaTest extends WebTestCase
     public function testResetIndexAddsMappings()
     {
         $client = $this->createClient(array('test_case' => 'Basic'));
+        $resetter = $this->getResetter($client);
+        $resetter->resetIndex('index');
 
         $type = $this->getType($client);
         $mapping = $type->getMapping();
-        $resetter = $this->getResetter($client);
-
-        $resetter->resetIndex('index');
-
 
         $this->assertNotEmpty($mapping, 'Mapping was populated');
 

--- a/Tests/Functional/MappingToElasticaTest.php
+++ b/Tests/Functional/MappingToElasticaTest.php
@@ -40,10 +40,9 @@ class MappingToElasticaTest extends WebTestCase
         $parent = $this->getType($client, 'parent');
         $mapping = $parent->getMapping();
 
-        $this->assertEquals('my_analyzer', $mapping['parent']['index_analyzer']);
-        $this->assertEquals('whitespace', $mapping['parent']['search_analyzer']);
+        $this->assertArrayHasKey('field1', $mapping['parent']['properties']);
+        $this->assertArrayHasKey('field2', $mapping['parent']['properties']);
     }
-
 
     public function testORMResetIndexAddsMappings()
     {

--- a/Tests/Functional/app/Basic/config.yml
+++ b/Tests/Functional/app/Basic/config.yml
@@ -47,12 +47,10 @@ fos_elastica:
                                 type: date
                     mappings:
                         field1: ~
-                        field2: ~
-                    search_analyzer: whitespace
-                    index_analyzer: my_analyzer
+                        field2:
+                            type: integer
                 type:
                     dynamic: strict
-                    search_analyzer: my_analyzer
                     date_detection: false
                     dynamic_date_formats: [ 'yyyy-MM-dd' ]
                     dynamic_templates:
@@ -83,9 +81,6 @@ fos_elastica:
                                 content: ~
                         multiple:
                             type: "multi_field"
-                            properties:
-                                name: ~
-                                position: ~
                         user:
                             type: "object"
                         approver:
@@ -99,8 +94,6 @@ fos_elastica:
                         dynamic_allowed: { type: object, dynamic: true }
                     _parent:
                         type: "parent"
-                        property: "parent"
-                        identifier: "id"
                 null_mappings:
                     mappings: ~
         empty_index: ~


### PR DESCRIPTION
These are the fixes that are missing to bring your pull request (https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1002) up-to-date with the latest changes of ES2.x.

This is what I've done:
- [X] Moved the resetting of the index back to the top of the `MappingToElasticaTest` test
- [X] Renamed `index_analyzer` to `analyzer` as per https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_mapping_changes.html#_analyzer_mappings
- [X] Removed analyzer configuration in parent mapping, as per https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_mapping_changes.html#_analyzer_mappings
- [X] Removed _parent type and identifier configuration in tests as per https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_mapping_changes.html#migration-meta-fields

Don't forget to update these changes in your PR if you merge this in, as it could mean breaking changes (which is ES's fault, not the bundle).
Hope this helps!
